### PR TITLE
fix: run ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Build
         run: yarn run build
 
+      - uses: actions/checkout@v2
       - name: Commit change
-        uses: actions/checkout@v2
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
error: a step cannot have both the `uses` and `run` keys